### PR TITLE
Update documentation to work on current systems

### DIFF
--- a/99-ipv6.conf
+++ b/99-ipv6.conf
@@ -1,2 +1,2 @@
 net.ipv6.conf.all.forwarding=1
-net.ipv6.conf.ens3.accept_ra=2
+net.ipv6.conf.eth0.accept_ra=2

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2016 Wido den Hollander <wido@widodh.nl>
+Copyright (c) 2021 Klaus Frank
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -122,6 +122,15 @@ systemctl start dhclient6-pd
 systemctl status dhclient6-pd
 ```
 
+## AppArmor
+
+On systems with AppArmor (e.g. Ubuntu 20.04.3 LTS) you need to add a rule to allow the script to execute.
+
+```bash
+sed -i '/\/{,usr\/}sbin\/dhclient flags=(attach_disconnected) {/a \ \ /etc/dhcp/docker-ipv6                                  Uxr,' /etc/apparmor.d/sbin.dhclient
+systemctl restart apparmor.service
+```
+
 ## Docker IPv6 hook
 The `docker-ipv6` dhclient hook in this repository should be placed in
 `/etc/dhcp/` where it will be executed after dhclient obtains a prefix.

--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@ use a IPv6 prefix obtained through DHCPv6 Prefix Delegation.
 
 This allows containers to use native IPv6 without any need for proxies.
 
-The scripts and tooling in this repository were tested on Ubuntu 14.04 (upstart)
-and 16.04 (systemd).
+The scripts and tooling in this repository were tested on:
+* Ubuntu 14.04 (upstart)
+* Ubuntu 16.04 (systemd)
+* ArchLinux rolling 2021-10-24 (systemd + systemd-networkd)
 
 # Prefix Delegation
 [Prefix Delegation](https://tools.ietf.org/html/rfc37690) (PD) is a mechanism which allows a client to request a
@@ -20,122 +22,160 @@ the --ipv6 flag.
 
 For example:
 
-```docker daemon --ipv6 --fixed-cidr-v6=2001:db8:100::/80```
+```dockerd --ipv6 --fixed-cidr-v6=2001:db8:100::/80```
 
 IPv6 addresses of Docker containers are based on the MAC address. A /80 subnet
-combined with the 48-bits of a MAC address sums op to 128-bits for a full IPv6
+combined with the 48-bits of a MAC address sums up to 128-bits for a full IPv6
 address.
 
 More information about Docker and IPv6 can be found in Docker's [documentation](https://docs.docker.com/engine/userguide/networking/default_network/ipv6/).
 
-## sysctl
+# Interface
+**NOTE:**
+This documentation uses `eth0` as an example interface.
+Change this in this accordingly in all commands and configurationfiles.
+
+Replace all occurences of eth0 by your primary interface.
+With newer kernels this might be something like *ens3*.
+
+# Dependencies
+
+Install the packages required for these commands:
+* sipcalc
+* grep
+* head
+* awk
+* command
+* dhclient
+
+# Kernel settings
+
+## systemd-networkd
+
+Make sure these settings are set within your network unit (See https://www.freedesktop.org/software/systemd/man/systemd.network.html):
+```ini
+[Network]
+DHCP=yes
+IPv6AcceptRA=yes
+IPForward=yes
+```
+
+Now restart systemd-networkd via `systemctl restart systemd-networkd` to load the changed configuration
+
+## without systemd-networkd (sysctl)
 A few sysctl settings have to be applied for IPv6 to work properly.
 
+To do so create `/etc/sysctl.d/99-ipv6.conf` and add:
 
-To do so create */etc/sysctl.d/99-ipv6.conf* and add:
-
-<pre>net.ipv6.conf.all.forwarding=1
-net.ipv6.conf.eth0.accept_ra=2</pre>
-
-**NOTE:** Replace eth0 by your primary interface. This might be *ens3* on newer kernels.
+```ini
+net.ipv6.conf.all.forwarding=1
+net.ipv6.conf.eth0.accept_ra=2
+```
 
 You can now apply these settings:
 
-<pre>sysctl -p /etc/sysctl.d/99-ipv6.conf</pre>
+```bash
+sysctl -p /etc/sysctl.d/99-ipv6.conf
+```
 
-A reboot of the system is suggested to make sure the settings are applied.
+You can also apply these settings **temporarily** until a reboot by running this instead:
+```
+sysctl net.ipv6.conf.all.forwarding=1
+sysctl net.ipv6.conf.eth0.accept_ra=2
+```
 
 # dhclient
-dhclient is part of ISC DHCP and can request a IPv6 Prefix through DHCPv6.
+dhclient is part of ISC DHCP and can request an IPv6 Prefix through DHCPv6.
 
-In order to do so, dhclient should be run with these flags:
+Therefore run dhclient with these flags:
 
-```dhclient -6 -P eth0```
+```bash
+dhclient -6 -P -d eth0
+```
 
 It will request a prefix through DHCPv6.
+The `-d` keeps dhclient running in the foreground.
 
-You can find the DHCPv6 information in */var/lib/dhcp/dhclient6.leases*
+You can find the DHCPv6 information in `/var/lib/dhcp/dhclient6.leases`
 
-## Ubuntu 14.04: Upstart
-Under Ubuntu 14.04 you can run dhclient using upstart to
-request the prefix and renew then needed.
+## Upstart
+Under Upstart (e.g. Ubuntu 14.04) you can run dhclient for Prefix Delegation
+using the provided configuration file.
+Just place `dhclient6-pd.conf` in `/etc/init/dhclient6-pd.conf`
+to have upstart request the prefix and renew when needed.
 
-See the upstart file in the repository to do so.
+Now start dhclient:
+```bash
+sudo start dhclient6-pd
+```
 
-You should place this file in */etc/init/dhclient6-pd.conf*
-
-Afterwards you can start and stop with:
-
-``sudo start dhclient6-pd``
-
-``sudo stop dhclient6-pd``
-
-## Ubuntu 16.04: systemd
-Ubuntu 16.04 using systemd and to run dhclient for Prefix Delegation to have to install *dhclient6-pd.service* in */etc/systemd/system/*
+## systemd
+Using systemd (e.g. Ubuntu 16.04) you can run dhclient for Prefix Delegation
+using the provided configuration file.
+Just place `dhclient6-pd.service` in `/etc/systemd/system/`
+to have systemd request the prefix and renew when needed.
 
 Now reload systemd and start dhclient:
-
-<pre>systemctl daemon-reload</pre>
-
-<pre>systemctl start dhclient6-pd</pre>
-
-<pre>systemctl status dhclient6-pd</pre>
-
-### Interface
-By default it uses eth0 as the configured interface. Change this in the service file if this differs on your system.
-
-With newer kernels this might be *ens3* for example.
-
-### ifupdown / interfaces file
-The ifupdown package on Ubuntu is responsible for configuring network interfaces under Debian and Ubuntu.
-
-I wrote a [patch](https://anonscm.debian.org/cgit/collab-maint/ifupdown.git/commit/?id=9af9a607274bec491ca165f9b8af6af26bbdf585) for ifupdown so that
-you can configure the network stack to perform the Prefix Delegation request for you.
-
-When Ubuntu and Debian apply this patch you can use it in your interfaces file:
-
-<pre>iface eth0 inet6 auto
-  dhcp 1
-  request_prefix 1</pre>
-
-Hopefully this makes it into Ubuntu 16.04.
+```bash
+systemctl daemon-reload
+systemctl start dhclient6-pd
+systemctl status dhclient6-pd
+```
 
 ## Docker IPv6 hook
-The *docker-ipv6* dhclient hook in this repository should be placed in
-**/etc/dhcp/dhclient-enter-hooks.d/** where it will be executed after dhclient
-obtains a prefix.
+The `docker-ipv6` dhclient hook in this repository should be placed in
+`/etc/dhcp/` where it will be executed after dhclient obtains a prefix.
 
 The hook will get the first **/80** subnet out of the delegated prefix and
-write it to */etc/docker/ipv6.prefix*
+write it to `/etc/docker/ipv6.prefix`
 
 The Docker daemon is then restarted so it will use the new subnet as the fixed
 IPv6 cidr.
 
-Depending on your Ubuntu version (14.04 or 16.04) configuration has to be done differently due to the Upstart vs systemd changes. The end result is the same.
+Depending on your system (upstart vs systemd), configuration has to be done differently.
+The end result is the same.
 
 Afterwards you can print the processlist and see docker running with these arguments:
+```bash
+/usr/bin/dockerd --ipv6 --fixed-cidr-v6=2001:00db8:100:0000:0000:0000:0000:0000/80
+```
 
-``/usr/bin/docker daemon --ipv6 --fixed-cidr-v6=2001:00db8:100:0000:0000:0000:0000:0000/80``
+Before changing the startup parameters, make sure that neither `ipv6` nor `fixed-cidr-v6`
+are specified within `/etc/docker/daemon.json`
 
-### Ubuntu 14.04
-In order for this to work the *DOCKER_OPTS* in /etc/default/docker should be set to:
+### Upstart
+With systems using Upstart (like Ubuntu 14.04) you can specify the command line options
+within a configuration file within `/etc/default`.
 
-```DOCKER_OPTS="--ipv6 --fixed-cidr-v6=`cat /etc/docker/ipv6.prefix`"```
+Set this within the file `/etc/default/docker`:
+```bash
+DOCKER_OPTS="--ipv6 --fixed-cidr-v6=`cat /etc/docker/ipv6.prefix`"
+```
 
-### Ubuntu 16.04
-First we copy the systemd service file for docker to /etc:
+### Systemd
+With systems using Systemd (like Ubuntu 16.04) you can specify the command line options
+within the unit file itself.
 
-<pre>cp /lib/systemd/system/docker.service /etc/systemd/system</pre>
+Edit the docker service via:
+```bash
+systemctl edit docker.service
+```
+and modify the `ExecStart` command like this:
+```ini
+### Editing /etc/systemd/system/docker.service.d/override.conf
+### Anything between here and the comment below will become the new content of the file
 
-Now modify the *ExecStatrt* line so that it contains:
+[Service]
+ExecStart=
+ExecStart=/bin/bash -c "/usr/bin/dockerd --ipv6 --fixed-cidr-v6=`cat /etc/docker/ipv6.prefix` -H fd://"
 
-<pre>ExecStart=/bin/bash -c "/usr/bin/docker daemon --ipv6 --fixed-cidr-v6=`cat /etc/docker/ipv6.prefix` -H fd://"</pre>
+### Lines below this comment will be discarded
+```
 
 Now reload systemd and stop/start Docker:
 
-<pre>systemctl daemon-reload</pre>
-
-<pre>systemctl stop docker</pre>
-
-<pre>systemctl start docker</pre>
-
+```bash
+systemctl daemon-reload
+systemctl stop docker
+systemctl start docker
+```

--- a/README.md
+++ b/README.md
@@ -1,28 +1,34 @@
 # Docker IPv6
+
 This respository contains various scripts and tools to enable [Docker](https://www.docker.com/) to
 use a IPv6 prefix obtained through DHCPv6 Prefix Delegation.
 
 This allows containers to use native IPv6 without any need for proxies.
 
 The scripts and tooling in this repository were tested on:
+
 * Ubuntu 14.04 (upstart)
 * Ubuntu 16.04 (systemd)
 * ArchLinux rolling 2021-10-24 (systemd + systemd-networkd)
 
-# Prefix Delegation
+## Prefix delegation
+
 [Prefix Delegation](https://tools.ietf.org/html/rfc37690) (PD) is a mechanism which allows a client to request a
 IPv6 prefix to be routed towards that host.
 
 Usually a client will obtain a prefix larger than a /64 to allow splitting
 up this prefix in multiple smaller prefixes.
 
-# Docker and IPv6
+## Docker and IPv6
+
 Docker can use IPv6 for it's containers if you start the docker daemon with
 the --ipv6 flag.
 
 For example:
 
-```dockerd --ipv6 --fixed-cidr-v6=2001:db8:100::/80```
+```sh
+dockerd --ipv6 --fixed-cidr-v6=2001:db8:100::/80
+```
 
 IPv6 addresses of Docker containers are based on the MAC address. A /80 subnet
 combined with the 48-bits of a MAC address sums up to 128-bits for a full IPv6
@@ -30,7 +36,8 @@ address.
 
 More information about Docker and IPv6 can be found in Docker's [documentation](https://docs.docker.com/engine/userguide/networking/default_network/ipv6/).
 
-# Interface
+## Interface
+
 **NOTE:**
 This documentation uses `eth0` as an example interface.
 Change this in this accordingly in all commands and configurationfiles.
@@ -38,9 +45,10 @@ Change this in this accordingly in all commands and configurationfiles.
 Replace all occurences of eth0 by your primary interface.
 With newer kernels this might be something like *ens3*.
 
-# Dependencies
+## Dependencies
 
 Install the packages required for these commands:
+
 * sipcalc
 * grep
 * head
@@ -48,11 +56,12 @@ Install the packages required for these commands:
 * command
 * dhclient
 
-# Kernel settings
+## Linux kernel settings
 
-## systemd-networkd
+### systemd-networkd
 
 Make sure these settings are set within your network unit (See https://www.freedesktop.org/software/systemd/man/systemd.network.html):
+
 ```ini
 [Network]
 DHCP=yes
@@ -62,7 +71,8 @@ IPForward=yes
 
 Now restart systemd-networkd via `systemctl restart systemd-networkd` to load the changed configuration
 
-## without systemd-networkd (sysctl)
+### without systemd-networkd (sysctl)
+
 A few sysctl settings have to be applied for IPv6 to work properly.
 
 To do so create `/etc/sysctl.d/99-ipv6.conf` and add:
@@ -79,12 +89,14 @@ sysctl -p /etc/sysctl.d/99-ipv6.conf
 ```
 
 You can also apply these settings **temporarily** until a reboot by running this instead:
+
 ```
 sysctl net.ipv6.conf.all.forwarding=1
 sysctl net.ipv6.conf.eth0.accept_ra=2
 ```
 
-# dhclient
+## dhclient
+
 dhclient is part of ISC DHCP and can request an IPv6 Prefix through DHCPv6.
 
 Therefore run dhclient with these flags:
@@ -98,31 +110,35 @@ The `-d` keeps dhclient running in the foreground.
 
 You can find the DHCPv6 information in `/var/lib/dhcp/dhclient6.leases`
 
-## Upstart
+### Upstart
+
 Under Upstart (e.g. Ubuntu 14.04) you can run dhclient for Prefix Delegation
 using the provided configuration file.
 Just place `dhclient6-pd.conf` in `/etc/init/dhclient6-pd.conf`
 to have upstart request the prefix and renew when needed.
 
 Now start dhclient:
+
 ```bash
 sudo start dhclient6-pd
 ```
 
-## systemd
+### systemd
+
 Using systemd (e.g. Ubuntu 16.04) you can run dhclient for Prefix Delegation
 using the provided configuration file.
 Just place `dhclient6-pd.service` in `/etc/systemd/system/`
 to have systemd request the prefix and renew when needed.
 
 Now reload systemd and start dhclient:
+
 ```bash
 systemctl daemon-reload
 systemctl start dhclient6-pd
 systemctl status dhclient6-pd
 ```
 
-## AppArmor
+### AppArmor
 
 On systems with AppArmor (e.g. Ubuntu 20.04.3 LTS) you need to add a rule to allow the script to execute.
 
@@ -131,7 +147,8 @@ sed -i '/\/{,usr\/}sbin\/dhclient flags=(attach_disconnected) {/a \ \ /etc/dhcp/
 systemctl restart apparmor.service
 ```
 
-## Docker IPv6 hook
+### Docker IPv6 hook
+
 The `docker-ipv6` dhclient hook in this repository should be placed in
 `/etc/dhcp/` where it will be executed after dhclient obtains a prefix.
 
@@ -145,6 +162,7 @@ Depending on your system (upstart vs systemd), configuration has to be done diff
 The end result is the same.
 
 Afterwards you can print the processlist and see docker running with these arguments:
+
 ```bash
 /usr/bin/dockerd --ipv6 --fixed-cidr-v6=2001:00db8:100:0000:0000:0000:0000:0000/80
 ```
@@ -152,24 +170,30 @@ Afterwards you can print the processlist and see docker running with these argum
 Before changing the startup parameters, make sure that neither `ipv6` nor `fixed-cidr-v6`
 are specified within `/etc/docker/daemon.json`
 
-### Upstart
+#### Upstart
+
 With systems using Upstart (like Ubuntu 14.04) you can specify the command line options
 within a configuration file within `/etc/default`.
 
 Set this within the file `/etc/default/docker`:
+
 ```bash
 DOCKER_OPTS="--ipv6 --fixed-cidr-v6=`cat /etc/docker/ipv6.prefix`"
 ```
 
-### Systemd
+#### Systemd
+
 With systems using Systemd (like Ubuntu 16.04) you can specify the command line options
 within the unit file itself.
 
 Edit the docker service via:
+
 ```bash
 systemctl edit docker.service
 ```
+
 and modify the `ExecStart` command like this:
+
 ```ini
 ### Editing /etc/systemd/system/docker.service.d/override.conf
 ### Anything between here and the comment below will become the new content of the file
@@ -188,3 +212,9 @@ systemctl daemon-reload
 systemctl stop docker
 systemctl start docker
 ```
+
+## See also
+
+* [Public IPv6 on containers](https://discuss.linuxcontainers.org/t/public-ipv6-on-containers/17338) — with some solutions.
+   + result published into [Using public IPv6 with LXD containers](https://blog.sifrmoja.xyz/posts/public-ipv6-lxd/): Mikrotik RouterOS, Ubuntu.
+* [Routable IPV6 with prefix delegation](https://discuss.linuxcontainers.org/t/routable-ipv6-with-prefix-delegation/20129) — a question, no answers.

--- a/dhclient6-pd.conf
+++ b/dhclient6-pd.conf
@@ -9,4 +9,4 @@ umask 022
 
 console log
 
-exec dhclient -6 -P -d eth0
+exec dhclient -6 -P -d -sf /etc/dhcp/docker-ipv6 eth0

--- a/dhclient6-pd.service
+++ b/dhclient6-pd.service
@@ -6,7 +6,7 @@ After=network.target network-online.target
 [Service]
 Type=simple
 Environment=NETWORK_INTERFACE=eth0
-ExecStart=/sbin/dhclient -6 -P -d ${NETWORK_INTERFACE}
+ExecStart=/sbin/dhclient -6 -P -d -sf /etc/dhcp/docker-ipv6 ${NETWORK_INTERFACE}
 Restart=always
 RestartSec=10s
 

--- a/docker-ipv6
+++ b/docker-ipv6
@@ -20,17 +20,33 @@
 # DOCKER_OPTS="--ipv6 --fixed-cidr-v6=`cat /etc/docker/ipv6.prefix`"
 #
 # This script requires sipcalc to function
-command -v sipcalc >/dev/null 2>&1 || exit 0
+if ! command -v sipcalc >/dev/null 2>&1
+then
+  exit 1
+fi
 
 SUBNET_SIZE=80
 DOCKER_ETC_DIR="/etc/docker"
 DOCKER_PREFIX_FILE="${DOCKER_ETC_DIR}/ipv6.prefix"
 
-if [ ! -z "$new_ip6_prefix" ]; then
+if [ ! -z "$new_ip6_prefix" ]
+then
+    # new_ip6_prefix is the whole delegated prefix
+    # SUBNET_SIZE is the desired size of the subnet we want to assign.
+    # Now we use sipcalc to slice new_ip6_prefix into SUBNET_SIZE big chunks.
+    # SUBNET contains the address of the first chunk.
     SUBNET=$(sipcalc -S $SUBNET_SIZE $new_ip6_prefix|grep Network|head -n 1|awk '{print $3}')
+    # Write new prefix into docker configuration.
     echo "${SUBNET}/${SUBNET_SIZE}" > $DOCKER_PREFIX_FILE
 
-    if [ "$old_ip6_prefix" != "$new_ip6_prefix" ]; then
-        service docker restart
+    # Restart docker to update new configuration
+    if [ "$old_ip6_prefix" != "$new_ip6_prefix" ]
+    then
+        if command -v systemctl &> /dev/null
+        then
+            systemctl restart docker.service
+        else
+            service docker restart
+        fi
     fi
 fi

--- a/docker-ipv6
+++ b/docker-ipv6
@@ -35,7 +35,7 @@ then
     # SUBNET_SIZE is the desired size of the subnet we want to assign.
     # Now we use sipcalc to slice new_ip6_prefix into SUBNET_SIZE big chunks.
     # SUBNET contains the address of the first chunk.
-    SUBNET=$(sipcalc -S $SUBNET_SIZE $new_ip6_prefix|grep Network|head -n 1|awk '{print $3}')
+    SUBNET=$(sipcalc -S $SUBNET_SIZE $new_ip6_prefix|grep -m 1 Network|awk '{print $3}')
     # Write new prefix into docker configuration.
     echo "${SUBNET}/${SUBNET_SIZE}" > $DOCKER_PREFIX_FILE
 


### PR DESCRIPTION
Update documentation to work on current systems

* Fix eth0/ens3 inconsistency
* Rewrite Readme.md for more clarity
* Test with Archlinux (systemd and systemd-networkd)
* Fix dhcp callback script to also restart docker on systems with systemd
* Update service files to actually invoke the script (was not invoked for me when placed according to the old version of the documentation)
* replace `<pre>` HTML tags with pure markdown syntax ` ``` `
* Fixes #1 by clarifying details with configuration and daemon.json
* Add fix for AppArmor